### PR TITLE
Enable Renovate automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>miscord-dev/.github:renovate-config"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Enables automerge for minor and patch updates (excludes pre-1.0.0 packages for safety)
- Enables automerge for lock file maintenance updates
- Follows Renovate best practices from documentation

## Benefits
- Reduces manual intervention for safe dependency updates
- Keeps dependencies up-to-date automatically
- Maintains safety by excluding major updates and pre-1.0.0 packages

## Test plan
- [ ] Verify Renovate processes the configuration correctly
- [ ] Monitor initial automerge behavior with minor/patch updates
- [ ] Confirm lock file maintenance updates are handled automatically

🤖 Generated with [Claude Code](https://claude.ai/code)