### PR TITLE
Fix deprecated actions/upload-release-asset action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,11 +114,6 @@ jobs:
 
       - name: Upload manifests to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dexchange-manifests.yaml
-          asset_name: dexchange-manifests.yaml
-          asset_content_type: application/x-yaml
+          files: ./dexchange-manifests.yaml


### PR DESCRIPTION
## Summary
- Replaces deprecated `actions/upload-release-asset@v1` with `softprops/action-gh-release@v2`
- Fixes "Input required and not supplied: upload_url" error
- Simplifies configuration by removing deprecated parameters

## Changes
- Updated `.github/workflows/docker.yml` to use modern release asset upload action
- Removed unnecessary environment variables and complex parameter configuration
- Uses simpler `files` parameter instead of individual asset parameters

## Benefits
- Eliminates workflow errors related to deprecated action
- Uses actively maintained and supported GitHub action
- Cleaner and more maintainable workflow configuration

## Test plan
- [ ] Verify workflow runs successfully on tag creation
- [ ] Confirm manifests are properly uploaded to releases
- [ ] Test with next version release

🤖 Generated with [Claude Code](https://claude.ai/code)