### PR TITLE
Replace setup-kustomize action with direct curl installation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,11 +97,11 @@ jobs:
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
       # Generate and upload manifests for tag builds (releases)
-      - name: Setup Kustomize
+      - name: Install Kustomize
         if: startsWith(github.ref, 'refs/tags/')
-        uses: imranismail/setup-kustomize@v1
-        with:
-          kustomize-version: "5.6.0"
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
 
       - name: Generate manifests with release image
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- Replaces third-party `imranismail/setup-kustomize` action with direct installation using curl
- Uses the official Kustomize installation script from the kubernetes-sigs repository
- Eliminates dependency on external GitHub Actions

## Changes
- Removed `uses: imranismail/setup-kustomize@v1` step
- Added direct installation using the official installation script
- Installs latest Kustomize version using `curl` and official script

## Benefits
- Reduces dependency on third-party actions
- Uses official installation method recommended by Kustomize maintainers
- More reliable and maintainable approach
- Always gets the latest version automatically

## Test plan
- [ ] Verify Kustomize installs correctly in CI environment
- [ ] Confirm manifest generation works with direct installation
- [ ] Test workflow execution on tag creation

🤖 Generated with [Claude Code](https://claude.ai/code)