### PR TITLE
Fix GitHub release upload permissions error

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.


### PR DESCRIPTION
## Summary
- Fixes "Resource not accessible by integration" error when uploading to GitHub releases
- Changes workflow permissions from `contents: read` to `contents: write`
- Required for `softprops/action-gh-release` to create and update releases

## Problem
The workflow was failing with:
```
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v0.0.3: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration
```

## Root Cause
The `softprops/action-gh-release` action requires `contents: write` permission to:
- Create new releases
- Update existing releases
- Upload assets to releases

The workflow only had `contents: read` permission, which prevented the action from accessing the GitHub Releases API.

## Solution
- Updated job permissions to include `contents: write`
- Maintains existing `packages: write` and `id-token: write` permissions
- Enables successful release asset uploads

## Test plan
- [ ] Verify workflow runs successfully on tag creation
- [ ] Confirm manifests are uploaded to releases without permission errors
- [ ] Test with next version release

🤖 Generated with [Claude Code](https://claude.ai/code)